### PR TITLE
Update PeakRDL plugin to use base class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7.2"
 systemrdl-compiler = "^1.25.0"
-peakrdl = { version = "^0.3.0", optional = true }
+peakrdl = { version = "^0.7.0", optional = true }
 py-markdown-table = "^0.3.3"
 
 [tool.poetry.extras]

--- a/src/peakrdl_markdown/__peakrdl__.py
+++ b/src/peakrdl_markdown/__peakrdl__.py
@@ -4,6 +4,8 @@ __authors__ = ["Marek Pikuła <marek.pikula at embevity.com>"]
 
 from typing import TYPE_CHECKING
 
+from peakrdl.plugins.exporter import ExporterSubcommandPlugin #pylint: disable=import-error
+
 from .exporter import MarkdownExporter
 
 if TYPE_CHECKING:
@@ -13,7 +15,7 @@ if TYPE_CHECKING:
     from systemrdl.node import AddrmapNode, RootNode  # type: ignore
 
 
-class Exporter:  # pylint: disable=too-few-public-methods
+class Exporter(ExporterSubcommandPlugin):  # pylint: disable=too-few-public-methods
     """PeakRDL Markdown exporter plug-in."""
 
     short_desc = "Generate Markdown documentation"


### PR DESCRIPTION
As you might have seen, I reworked how PeakRDL handles plugins slightly.
Starting in v0.7.0, all importer & exporter plugin descriptor classes now have to be derived off of a base class.
This is something I initially hesitated to do, but after a while found it cumbersome to not have proper class inheritance here.
Unfortunately this kinda breaks compatibility, but hey this is all beta stuff so far anyways and I was bound to change my mind on these things :wink:

This PR addresses the compatibility change.